### PR TITLE
Fix flaky

### DIFF
--- a/src/test/java/com/fasterxml/jackson/dataformat/xml/ser/TestSerializationWithFilter.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/xml/ser/TestSerializationWithFilter.java
@@ -2,6 +2,7 @@ package com.fasterxml.jackson.dataformat.xml.ser;
 
 import com.fasterxml.jackson.annotation.JsonFilter;
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.FilterProvider;
 import com.fasterxml.jackson.databind.ser.PropertyFilter;
@@ -42,14 +43,16 @@ public class TestSerializationWithFilter extends XmlTestBase
             {
                 if (include(writer) && writer.getName().equals("a")) {
                     int a = ((Item) pojo).a;
-                    if (a <= 0)
+                    if (a <= 0){
                         return;
+                    }
                 }
                 super.serializeAsField(pojo, jgen, provider, writer);
             }
         };
         FilterProvider filterProvider = new SimpleFilterProvider().addFilter("filter", filter);
         xmlMapper.setFilterProvider(filterProvider);
+        xmlMapper.enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS);
         String act = xmlMapper.writeValueAsString(bean);
         assertEquals(exp, act);
     }

--- a/src/test/java/com/fasterxml/jackson/dataformat/xml/ser/TestSerializationWithFilter.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/xml/ser/TestSerializationWithFilter.java
@@ -1,6 +1,7 @@
 package com.fasterxml.jackson.dataformat.xml.ser;
 
 import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.SerializerProvider;
@@ -11,6 +12,7 @@ import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.fasterxml.jackson.dataformat.xml.XmlTestBase;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlText;
 
 /**
@@ -19,11 +21,14 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlText;
 public class TestSerializationWithFilter extends XmlTestBase
 {
     @JsonFilter("filter")
+    @JsonPropertyOrder(alphabetic=true)
     static class Item
     {
-        @JacksonXmlText
+        @JacksonXmlProperty(localName = "a")
         public int a;
+        @JacksonXmlProperty(localName = "b")
         public int b;
+        @JacksonXmlProperty(localName = "c")
         public int c;
     }
 


### PR DESCRIPTION
So this testPullRequest616 test is flaky because the JacksonXml and Xml mapper does not guarantee a fixed order of the elements in the map every time it is used. This test and this project want the order to be alphabetical, but it does not follow the alphabetical rule every time the test is run. What I changed is setting up local names for the item's elements and making the sorting rule for the JacksonXml mapper alphabetical. Then, every time this test was triggered, it would follow the same rule and would be flaky.